### PR TITLE
add Pod encoding marker

### DIFF
--- a/lib/WWW/Tabela/Fipe.pm
+++ b/lib/WWW/Tabela/Fipe.pm
@@ -233,6 +233,8 @@ sub on_finish {
     $self->robot->writer->write( $self->veiculos );
 }
 
+=encoding UTF-8
+
 =head1 NAME
 
 WWW::Tabela::Fipe - Baixe a tabela fipe completa mantenha-se atualizado


### PR DESCRIPTION
Hi,

The lack of encoding marker causes mojibakes in place of non-ASCII symbols on [sco](http://search.cpan.org/~hernan/WWW-Tabela-Fipe-0.002/lib/WWW/Tabela/Fipe.pm): `Ã© sÃ³ executar`.

[MetaCPAN](https://metacpan.org/pod/WWW::Tabela::Fipe) gets it right, but warns at the bottom of the page.

Explicit encoding marker should fix both of those.

Cheers,
Sergey
