### PR TITLE
switch File::Slurp to File::Slurp::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ WriteMakefile(
                      'HTTP::Request::Common'    => 0,
                      'HTML::Robot::Scrapper'    => 0,
                      'Data::Printer'            => 0,
-                     'File::Slurp'              => 0,
+                     'File::Slurp::Tiny'        => 0,
                      'HTTP::CookieJar'          => 0,
                      'JSON::XS'                 => 0,
                     },

--- a/lib/WWW/Tabela/FipeWrite.pm
+++ b/lib/WWW/Tabela/FipeWrite.pm
@@ -1,6 +1,6 @@
 package WWW::Tabela::FipeWrite;
 use JSON::XS;
-use File::Slurp;
+use File::Slurp::Tiny qw( write_file );
 use Moo;
 
 sub write {


### PR DESCRIPTION
File::Slurp is known to be buggy, e.g. see [here](https://rt.cpan.org/Ticket/Display.html?id=83126).
